### PR TITLE
Add missing coin shop elephs, currently available on JP server

### DIFF
--- a/planner/json/misc_data.json
+++ b/planner/json/misc_data.json
@@ -446,13 +446,27 @@
         ]
     },
     "shop_characters": {
-        "10001": "JECoin",
         "10007": "RaidToken",
-        "10012": "JECoin",
-        "10013": "JECoin",
+        "13000": "RaidToken",
+        "13011": "RaidToken",
+        "23002": "RaidToken",
+        "23007": "RaidToken",
+        "26000": "RaidToken",
+        "26001": "RaidToken",
+        "20009": "RaidToken",
         "10016": "RareRaidToken",
         "10019": "RareRaidToken",
         "10020": "RareRaidToken",
+        "20013": "RareRaidToken",
+        "20002": "ArenaCoin",
+        "20003": "ArenaCoin",
+        "23001": "ArenaCoin",
+        "23004": "ArenaCoin",
+        "23006": "ArenaCoin",
+        "10038": "ArenaCoin",
+        "10001": "JECoin",
+        "10012": "JECoin",
+        "10013": "JECoin",
         "10021": "MasteryCertificate",
         "10022": "MasteryCertificate",
         "10023": "MasteryCertificate",
@@ -460,6 +474,23 @@
         "10027": "MasteryCertificate",
         "10031": "MasteryCertificate",
         "10032": "MasteryCertificate",
+        "10046": "MasteryCertificate",
+        "10047": "MasteryCertificate",
+        "10053": "MasteryCertificate",
+        "10054": "MasteryCertificate",
+        "10057": "MasteryCertificate",
+        "10062": "MasteryCertificate",
+        "10073": "MasteryCertificate",
+        "10087": "MasteryCertificate",
+        "10091": "MasteryCertificate",
+        "10092": "MasteryCertificate",
+        "10101": "MasteryCertificate",
+        "10102": "MasteryCertificate",
+        "20004": "MasteryCertificate",
+        "20022": "MasteryCertificate",
+        "20024": "MasteryCertificate",
+        "20028": "MasteryCertificate",
+        "20033": "MasteryCertificate",
         "10033": {
             "currency": "MasteryCertificate",
             "amount": 5,
@@ -472,43 +503,109 @@
             "cost": 2400,
             "times": 2
         },
-        "10046": "MasteryCertificate",
-        "10047": "MasteryCertificate",
-        "10053": "MasteryCertificate",
-        "10054": "MasteryCertificate",
         "10059": {
             "currency": "MasteryCertificate",
             "amount": 5,
             "cost": 2400,
             "times": 2
         },
-        "13000": "RaidToken",
+        "10074": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 2400,
+            "times": 2
+        },
+        "10086": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 2400,
+            "times": 2
+        },
+        "10098": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 2400,
+            "times": 2
+        },
+        "10100": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 2400,
+            "times": 2
+        },
+        "10111": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 2400,
+            "times": 2
+        },
+        "20041": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 2400,
+            "times": 2
+        },
         "13004": {
             "currency": "MasteryCertificate",
             "amount": 5,
             "cost": 1800,
             "times": 6
         },
-        "13011": "RaidToken",
         "16005": {
             "currency": "MasteryCertificate",
             "amount": 5,
             "cost": 1800,
             "times": 6
         },
-        "20002": "ArenaCoin",
-        "20003": "ArenaCoin",
-        "20004": "MasteryCertificate",
-        "20022": "MasteryCertificate",
-        "20030": "MasteryCertificate",
-        "23001": "ArenaCoin",
-        "23002": "RaidToken",
-        "23004": "ArenaCoin",
-        "23006": "ArenaCoin",
-        "23007": "RaidToken",
-        "26000": "RaidToken",
-        "26001": "RaidToken",
+        "16006": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "16007": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "16008": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "16009": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "16010": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
         "26006": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "26007": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "26008": {
+            "currency": "MasteryCertificate",
+            "amount": 5,
+            "cost": 1800,
+            "times": 6
+        },
+        "26009": {
             "currency": "MasteryCertificate",
             "amount": 5,
             "cost": 1800,


### PR DESCRIPTION
Updated shop elephs:

Yellow coins:
OCherino

Purple coins:
Chihiro:

PVP coins:
Miyako

Expert permits:
THaruna (removed)
NYHaruna
SIzumi
Toki
Nagisa
SHanako
Tomoe
SHinata
SUi
Fubuki
DHina
Michiru
SAyane
SShizuko
Makoto
DAko
AHoshino
Kuroko
BKazusa
BYoshimi
CHibiki
BYuzu
SSaori
SHiyori
Rio
UNeru

Didn't add THasumi, as archive gives enough elephs for UE50. 
Also reordered listed elephs in code, grouping them by currency.