### PR TITLE
Correct the number of times elephs can be bought for shop coins

### DIFF
--- a/planner/json/misc_data.json
+++ b/planner/json/misc_data.json
@@ -519,12 +519,12 @@
         "RaidToken": {
             "amount": 5,
             "cost": 50,
-            "times": 10
+            "times": 20
         },
         "RareRaidToken": {
             "amount": 5,
             "cost": 50,
-            "times": 5
+            "times": 10
         },
         "ArenaCoin": {
             "amount": 5,


### PR DESCRIPTION
Currently, the number of purchases per cycle is at 10 for yellow coins and at 5 for purple coins. This does not align with the ingame limits. 
![image](https://github.com/user-attachments/assets/fbb98ffc-a127-484b-94a4-e947b06ef99e)

Increased the number of available purchases to 20 and 10, respectively.
