### PR TITLE
Set all relevant skill levels to 1 upon character addition

### DIFF
--- a/planner/js/config.js
+++ b/planner/js/config.js
@@ -291,8 +291,8 @@ class StudentInvestment {
 
             1,
             1,
-            0,
-            0,
+            characterInfo?.StarGrade >= 2 ? 1 : 0,
+            characterInfo?.StarGrade >= 3 ? 1 : 0,
 
             0,
             0,
@@ -306,8 +306,8 @@ class StudentInvestment {
         var defaultTarget = StudentInvestment.Default(characterInfo);
         defaultTarget.ex = inputValidation.ex_target.default;
         defaultTarget.basic = inputValidation.basic_target.default;
-        defaultTarget.passive = inputValidation.passive_target.default;
-        defaultTarget.sub = inputValidation.sub_target.default;
+        defaultTarget.passive = characterInfo?.StarGrade >= 2 ? 1 : inputValidation.passive_target.default;
+        defaultTarget.sub = characterInfo?.StarGrade >= 3 ? 1 : inputValidation.sub_target.default;
 
         defaultTarget.bond = inputValidation.bond_target.default;
         defaultTarget.level = inputValidation.level_target.default;


### PR DESCRIPTION
At the moment, whenever adding any character to a collection, their skill levels will always be 1100.
![image](https://github.com/user-attachments/assets/882cab75-f407-4cf2-9bd2-b98eceb013ca)

This change makes it so that 2+ star units have their Enhanced skill set to 1, and 3 star units - their Sub to 1.
![image](https://github.com/user-attachments/assets/af4b9342-9a7f-4910-b142-513a782a67c3)
