### PR TITLE
Add a check for and use of overwrite string for buff names in skill descriptions

### DIFF
--- a/planner/js/pageLogic.js
+++ b/planner/js/pageLogic.js
@@ -3821,7 +3821,8 @@ function getSkillFormatted(charId, skill, level, targetLevel, targetUe) {
             let closeIndex = desc.substring(effectIndex).indexOf(">");
 
             let effectKey = desc.substring(effectIndex + 3, effectIndex + closeIndex);
-            let effectShort = GetBuffName("Buff_" + effectKey);
+            let effectOverwriteQuery = effectKey.match(/='(.+?)'/);
+            let effectShort = effectOverwriteQuery ? effectOverwriteQuery[1] : GetBuffName("Buff_" + effectKey);
 
             let paramRegex = new RegExp("<b:" + effectKey + ">", "g");
             desc = desc.replace(paramRegex, effectShort);
@@ -3831,7 +3832,8 @@ function getSkillFormatted(charId, skill, level, targetLevel, targetUe) {
             let closeIndex = desc.substring(effectIndex).indexOf(">");
 
             let effectKey = desc.substring(effectIndex + 3, effectIndex + closeIndex);
-            let effectShort = GetBuffName("Debuff_" + effectKey);
+            let effectOverwriteQuery = effectKey.match(/='(.+?)'/);
+            let effectShort = effectOverwriteQuery ? effectOverwriteQuery[1] : GetBuffName("Debuff_" + effectKey);
 
             let paramRegex = new RegExp("<d:" + effectKey + ">", "g");
             desc = desc.replace(paramRegex, effectShort);
@@ -3841,7 +3843,8 @@ function getSkillFormatted(charId, skill, level, targetLevel, targetUe) {
             let closeIndex = desc.substring(effectIndex).indexOf(">");
 
             let effectKey = desc.substring(effectIndex + 3, effectIndex + closeIndex);
-            let effectShort = GetBuffName("CC_" + effectKey);
+            let effectOverwriteQuery = effectKey.match(/='(.+?)'/);
+            let effectShort = effectOverwriteQuery ? effectOverwriteQuery[1] : GetBuffName("CC_" + effectKey);
 
             let paramRegex = new RegExp("<c:" + effectKey + ">", "g");
             desc = desc.replace(paramRegex, effectShort);
@@ -3851,7 +3854,8 @@ function getSkillFormatted(charId, skill, level, targetLevel, targetUe) {
             let closeIndex = desc.substring(effectIndex).indexOf(">");
 
             let effectKey = desc.substring(effectIndex + 3, effectIndex + closeIndex);
-            let effectShort = GetBuffName("Special_" + effectKey);
+            let effectOverwriteQuery = effectKey.match(/='(.+?)'/);
+            let effectShort = effectOverwriteQuery ? effectOverwriteQuery[1] : GetBuffName("Special_" + effectKey);
 
             let paramRegex = new RegExp("<s:" + effectKey + ">", "g");
             desc = desc.replace(paramRegex, effectShort);


### PR DESCRIPTION
Some skill descriptions have buff name overwrites (for example, singular version instead of plural). At the moment, the code considers these overwrites as a part of the buff name and doesn't attempt to use it correctly, resulting in undefined appearing in skill descriptions instead. This PR adds a check for the overwrite presence and then uses it.

Affected units and skills:

EN and ID:
Aris - Normal
Aru (New Year) - Sub
Mutsuki (New Year) - Sub
Kokona - Ex, Normal
Ui (Swimsuit) - Sub
Yukari - Sub
Momoi (Maid) - Sub
Mine (Idol) - Sub
Tomoe (Qipao) - Ex

KR:
Tsukuyo - Ex

JP:
Eimi - Enhanced+
Izumi - Enhanced+
Midori - Ex
Saori (Swimsuit) - Sub
Marina (Qipao) - Ex
Juri - Ex

TW and CN:
Hoshino (Swimsuit) - Ex
Utaha (Cheer Squad) - Ex
Hina (Dress) - Ex
Hina (Dress) - Sub
Shiroko*Terror - Ex

TH:
Haruna - Enhanced
Hifumi - Enhanced
Sumire - Enhanced
Cherino - Normal
Neru (Bunny) - Enhanced+
Asuna (Bunny) - Enhanced
Natsu - Enhanced
Chinatsu (Hot Spring) - Enhanced
Aru (New Year) - Enhanced
Akane - Enhanced+
Akari - Enhanced
Kirino - Enhanced
Haruka - Enhanced
Tsurugi (Swimsuit) - Enhanced+
Utaha - Sub
Ayane - Sub
Mari - Sub
Juri - Sub